### PR TITLE
Config as derive

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -15,6 +15,7 @@ pub fn start(mut conf: Config) {
     loop {
         loop {
             let cur_time = get_time().sec;
+            conf.items.sort_unstable();
             if let Some(c) = conf.items.iter().peekable().peek() {
                 if c.next_time > cur_time {
                     break;
@@ -96,6 +97,7 @@ pub fn start(mut conf: Config) {
                     }
             });
         }
+        conf.items.sort_unstable();
         if let Some(c) = conf.items.iter().peekable().peek() {
             thread::sleep(Duration::from_secs((c.next_time - get_time().sec) as u64));
         }

--- a/src/item.rs
+++ b/src/item.rs
@@ -45,14 +45,21 @@ impl ::std::fmt::Display for ItemError {
 
 /// The different kinds of items one can supervise
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Deserialize)]
-#[serde(untagged)]
+#[serde(tag = "type", rename_all = "lowercase")]
 pub enum ItemKind {
     /// Read the file at the given location, useful on Linux for the /sys dir for example
-    File(PathBuf),
+    File {
+        path: PathBuf
+    },
     /// Path to an executable with a list of arguments to be given to the executable
-    Command(PathBuf, Vec<String>),
+    Command {
+        path: PathBuf,
+        args: Vec<String>
+    },
     /// A string to be executed in a shell context
-    Shell(String),
+    Shell {
+        script: String
+    },
 }
 
 /// A single item, knowing when it is supposed to run next, what should be done and its key.
@@ -66,7 +73,7 @@ pub struct Item {
     #[serde(skip, default = "BTreeMap::new")]
     pub env: BTreeMap<String, String>,
 
-    #[serde(rename = "command")]
+    #[serde(rename = "input")]
     pub kind: ItemKind,
 }
 


### PR DESCRIPTION
This implements the `items` with a tagged enum (`type`), so we can easily differentiate between shell, file and single command inputs.  
An example config would be:
```toml
[general]
shell = "/usr/bin/bash"
output = "/tmp"

[[items]]
key = "ak-file-load"
interval = 6
input.type = "file"
input.path = "/proc/loadavg"

[[items]]
key = "ak-cmd-df"
interval = 6
input.type = "command"
input.path = "/usr/bin/df"
input.args = [ "-h", "/" ]

[[items]]
key = "ak-sh-free"
interval = 6
input.type = "shell"
input.script = "free | grep -E 'Speicher:|Mem:'"
```

I noticed that with multiple `items`, there's an endless loop, somewhat quickly filling up the file of the last specified item. This is due to not using the BinaryHeap anymore.
I worked around this by sorting the `Vec<Item>` before accessing it.

If the BinaryHeap cannot be used directly because of deserializing, a function like the for `conf::Config` might hide some of the ugliness (not tested, just a proposal):
```rust
pub fn items(&self) -> &Vec<Item> {
    self.items.sort_unstable();
    &self.items
}
```