### PR TITLE
Config as derive - Addendum

### DIFF
--- a/src/conf.rs
+++ b/src/conf.rs
@@ -169,18 +169,18 @@ mod tests {
 
     #[test]
     fn load() {
-        let data = "[general]
-         output = \"/tmp/test\"
+        let data = r#"[general]
+         output = "/tmp/test"
          [[items]]
-         key = \"os.uptime\"
+         key = "os.uptime"
          interval = 60
-         command = \"cat /proc/uptime | cut -d\' \' -f1\"
+         command = "cat /proc/uptime | cut -d' ' -f1"
 
          [[items]]
-         key = \"os.loadavg\"
+         key = "os.loadavg"
          interval = 1
-         command = \"cat /proc/loadavg | cut -d\' \' -f1\"
-";
+         command = "cat /proc/loadavg | cut -d' ' -f1"
+"#;
 
         let config = conf::load(&mut data.as_bytes(), PathBuf::from("")).unwrap();
         assert_eq!(config.items.len(), 2);
@@ -188,18 +188,18 @@ mod tests {
 
     #[test]
     fn no_duplicates() {
-        let data = "[general]
-         output = \"/tmp/test\"
+        let data = r#"[general]
+         output = "/tmp/test"
          [[items]]
-         key = \"os.uptime\"
+         key = "os.uptime"
          interval = 60
-         command = \"cat /proc/uptime | cut -d\' \' -f1\"
+         command = "cat /proc/uptime | cut -d' ' -f1"
 
          [[items]]
-         key = \"os.uptime\"
+         key = "os.uptime"
          interval = 1
-         command = \"cat /proc/loadavg | cut -d\' \' -f1\"
-";
+         command = "cat /proc/loadavg | cut -d' ' -f1"
+"#;
 
         let config = conf::load(&mut data.as_bytes(), PathBuf::from(""));
         assert!(config.is_err());
@@ -215,13 +215,13 @@ mod tests {
 
     #[test]
     fn output_dir() {
-        let data = "[general]
-        output = \"/tmp/test\"
+        let data = r#"[general]
+        output = "/tmp/test"
         [[items]]
-        key = \"os.battery\"
+        key = "os.battery"
         interval = 60
-        command = \"acpi\"
-        ";
+        command = "acpi"
+        "#;
         // Testcase 1: output-dir supplied by config file only
         let config = conf::load(&mut data.as_bytes(), PathBuf::new()).unwrap();
         assert_eq!(config.general.output, PathBuf::from("/tmp/test"));
@@ -232,12 +232,12 @@ mod tests {
         assert_eq!(config.general.output, PathBuf::from("/tmp/cmd_test"));
 
         // Testcase 3: Not output given, default should be used
-        let data = "[general]
+        let data = r#"[general]
         [[items]]
-        key = \"os.battery\"
+        key = "os.battery"
         interval = 60
-        command = \"acpi\"
-        ";
+        command = "acpi"
+        "#;
         let config = conf::load(&mut data.as_bytes(), PathBuf::new()).unwrap();
         let xdg_default_dir = match xdg::BaseDirectories::with_prefix("antikoerper").unwrap()
             .create_data_directory(&PathBuf::new()) {

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -171,15 +171,18 @@ mod tests {
     fn load() {
         let data = r#"[general]
          output = "/tmp/test"
+
          [[items]]
          key = "os.uptime"
          interval = 60
-         command = "cat /proc/uptime | cut -d' ' -f1"
+         input.type = "shell"
+         input.script = "cat /proc/uptime | cut -d' ' -f1"
 
          [[items]]
          key = "os.loadavg"
          interval = 1
-         command = "cat /proc/loadavg | cut -d' ' -f1"
+         input.type = "shell"
+         input.script = "cat /proc/loadavg | cut -d' ' -f1"
 "#;
 
         let config = conf::load(&mut data.as_bytes(), PathBuf::from("")).unwrap();
@@ -193,12 +196,14 @@ mod tests {
          [[items]]
          key = "os.uptime"
          interval = 60
-         command = "cat /proc/uptime | cut -d' ' -f1"
+         input.type = "shell"
+         input.script = "cat /proc/uptime | cut -d' ' -f1"
 
          [[items]]
          key = "os.uptime"
          interval = 1
-         command = "cat /proc/loadavg | cut -d' ' -f1"
+         input.type = "shell"
+         input.script = "cat /proc/loadavg | cut -d' ' -f1"
 "#;
 
         let config = conf::load(&mut data.as_bytes(), PathBuf::from(""));
@@ -220,7 +225,8 @@ mod tests {
         [[items]]
         key = "os.battery"
         interval = 60
-        command = "acpi"
+        input.type = "command"
+        input.path = "acpi"
         "#;
         // Testcase 1: output-dir supplied by config file only
         let config = conf::load(&mut data.as_bytes(), PathBuf::new()).unwrap();
@@ -236,7 +242,8 @@ mod tests {
         [[items]]
         key = "os.battery"
         interval = 60
-        command = "acpi"
+        input.type = "command"
+        input.path = "acpi"
         "#;
         let config = conf::load(&mut data.as_bytes(), PathBuf::new()).unwrap();
         let xdg_default_dir = match xdg::BaseDirectories::with_prefix("antikoerper").unwrap()

--- a/src/item.rs
+++ b/src/item.rs
@@ -114,14 +114,14 @@ mod tests {
             interval: 5,
             env: BTreeMap::new(),
             key: String::from("tests.one"),
-            kind: ItemKind::File(PathBuf::from("/dev/null")),
+            kind: ItemKind::File{ path: PathBuf::from("/dev/null") },
         });
         heap.push(Item {
             next_time: 3,
             interval: 5,
             env: BTreeMap::new(),
             key: String::from("tests.two"),
-            kind: ItemKind::File(PathBuf::from("/dev/null")),
+            kind: ItemKind::File{ path: PathBuf::from("/dev/null") },
         });
 
         if let Some(item) = heap.pop() {

--- a/src/item.rs
+++ b/src/item.rs
@@ -105,6 +105,8 @@ mod tests {
     use std::collections::BinaryHeap;
     use std::collections::BTreeMap;
 
+    use toml;
+
     use item::{Item,ItemKind};
 
     #[test]
@@ -130,5 +132,85 @@ mod tests {
         } else {
             unreachable!();
         }
+    }
+
+    #[test]
+    fn deser_item() {
+        let item_str = r#"
+            key = "os.loadavg"
+            interval = 10
+            input.type = "file"
+            input.path = "/proc/loadavg"
+        "#;
+        let item_deser : Result<Item, _> = toml::from_str(item_str);
+        assert!(item_deser.is_ok());
+        let item = item_deser.unwrap();
+        assert_eq!(item.key, "os.loadavg");
+        assert_eq!(item.interval, 10);
+    }
+
+    #[test]
+    fn deser_itemkind_file() {
+        let item_str = r#"
+            key = "os.loadavg"
+            interval = 10
+            input.type = "file"
+            input.path = "/proc/loadavg"
+        "#;
+        let item_deser : Result<Item, _> = toml::from_str(item_str);
+        assert!(item_deser.is_ok());
+        let item = item_deser.unwrap();
+        assert_eq!(item.kind, ItemKind::File{ path: PathBuf::from("/proc/loadavg") });
+    }
+
+    #[test]
+    fn deser_itemkind_shell() {
+        let item_str = r#"
+            key = "os.loadavg"
+            interval = 10
+            input.type = "shell"
+            input.script = "df /var | tail -1"
+        "#;
+        let item_deser : Result<Item, _> = toml::from_str(item_str);
+        assert!(item_deser.is_ok());
+        let item = item_deser.unwrap();
+        assert_eq!(item.kind, ItemKind::Shell{
+            script: String::from("df /var | tail -1")
+        });
+    }
+
+    #[test]
+    fn deser_itemkind_command_without_args() {
+        let item_str = r#"
+            key = "os.battery"
+            interval = 60
+            input.type = "command"
+            input.path = "acpi"
+        "#;
+        let item_deser : Result<Item, _> = toml::from_str(item_str);
+        assert!(item_deser.is_ok());
+        let item = item_deser.unwrap();
+        assert_eq!(item.kind, ItemKind::Command{
+            path: PathBuf::from("acpi"),
+            args: Vec::new()
+        });
+    }
+
+    #[test]
+    fn deser_itemkind_command_with_args() {
+        let item_str = r#"
+            key = "os.battery"
+            interval = 60
+            input.type = "command"
+            input.path = "acpi"
+            input.args = [ "-b", "-i" ]
+        "#;
+        let item_deser : Result<Item, _> = toml::from_str(item_str);
+        assert!(item_deser.is_ok());
+        let item = item_deser.unwrap();
+        assert_eq!(item.kind, ItemKind::Command{
+            path: PathBuf::from("acpi"),
+            args: vec![String::from("-b"), String::from("-i")]
+        });
     }
 }

--- a/src/item.rs
+++ b/src/item.rs
@@ -54,6 +54,7 @@ pub enum ItemKind {
     /// Path to an executable with a list of arguments to be given to the executable
     Command {
         path: PathBuf,
+        #[serde(default)]
         args: Vec<String>
     },
     /// A string to be executed in a shell context

--- a/src/item.rs
+++ b/src/item.rs
@@ -71,7 +71,7 @@ pub struct Item {
     pub interval: i64,
     pub key: String,
 
-    #[serde(skip, default = "BTreeMap::new")]
+    #[serde(default)]
     pub env: BTreeMap<String, String>,
 
     #[serde(rename = "input")]


### PR DESCRIPTION
There's actually more changed in this PR I thought there'd be, but well:

* fix the existing test
* add more extensive deserialization tests for `Item`
* use `r#"..."#` in multiline strings to enhance readability/reduce escaping
* remove the wrong `skip` directive for serde on `Item.env`
* add a default for `Itemkind::Command.args`, as not every command needs to have those.